### PR TITLE
Export some handy hexo related global functions to the Sass compiler context like [mamboer/hexo-renderer-scss]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/
 node_modules/
 package-lock.json
+yarn.lock
+.idea

--- a/README.md
+++ b/README.md
@@ -9,7 +9,22 @@ $ npm install --save hexo-renderer-dartsass
 ```
 
 ## Config
-Anything specified under the key `sass` in your `_config.yml` files will be passed directly to the `sass.render()` call. Check out the [Dart Sass API docs](https://github.com/sass/dart-sass#javascript-api) for all available settings.
+Anything specified under the key `sass` in your `_config.yml` files will be passed directly to the `sass.render()` call. 
+Check out the [Dart Sass API docs](https://github.com/sass/dart-sass#javascript-api) for all available settings.
+
+## Features
+1. Export some handy hexo related global functions to the Sass compiler context like [mamboer/hexo-renderer-scss].
+   - hexo-config($key)
+
+     Now you can use `hexo-config` function in your 'scss' files to access your hexo app's site configuration.
+
+     ```
+     $highlight_theme: hexo-config('highlight_theme')
+     ```
+     
+   - hexo-theme-config($key)
+
+     Similar to the `hexo-config`, you can use `hexo-theme-config` to access your hexo theme's configuration.
 
 ### _config.yml
 ```yaml
@@ -34,3 +49,4 @@ This plugin was created with reference to [knksmith57/hexo-renderer-sass]. Thank
 [node-sass]: https://github.com/andrew/node-sass
 [Dart Sass API docs]: https://github.com/sass/dart-sass#javascript-api
 [knksmith57/hexo-renderer-sass]: https://github.com/knksmith57/hexo-renderer-sass
+[mamboer/hexo-renderer-scss]: https://github.com/mamboer/hexo-renderer-scss

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-renderer-dartsass",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Sass renderer plugin for Hexo (use dartsass instead of libsass)",
   "main": "dist/",
   "files": [

--- a/spec/files/default-spec-config.sass
+++ b/spec/files/default-spec-config.sass
@@ -1,0 +1,5 @@
+html
+    body
+        width: 100%
+        background: to-lower-case(call("hexo-theme-config", 'color'))
+        color: to-lower-case(call('hexo-config', 'color'))

--- a/spec/files/default-spec-config.scss
+++ b/spec/files/default-spec-config.scss
@@ -1,0 +1,7 @@
+html {
+    body {
+        width: 100%;
+        background: to-lower-case(call("hexo-theme-config", 'color'));
+        color: to-lower-case(call('hexo-config', 'color'));
+    }
+}

--- a/spec/renderer.spec.ts
+++ b/spec/renderer.spec.ts
@@ -1,12 +1,12 @@
 import Hexo = require('hexo');
 import { make } from '../src/renderer';
 
-describe('Function `make`', ()=>{
+describe('Function `make`', () => {
     it('compile scss with default settings', async () => {
         const hexo = new Hexo();
         const data: Hexo.extend.RendererData = {
             path: __dirname + '/files/default.scss',
-            text: ''
+            text: '',
         };
         const result = await make.call(hexo, data, {});
         expect(result).toBe('html body {\n  width: 100%;\n}')
@@ -14,10 +14,10 @@ describe('Function `make`', ()=>{
 
     it('compile scss with custom config', async () => {
         const hexo = new Hexo();
-        hexo.config.sass = { indentWidth: 4 };
+        hexo.config.sass = {indentWidth: 4};
         const data: Hexo.extend.RendererData = {
             path: __dirname + '/files/default.scss',
-            text: ''
+            text: '',
         };
         const result = await make.call(hexo, data, {});
         expect(result).toBe('html body {\n    width: 100%;\n}')
@@ -25,11 +25,11 @@ describe('Function `make`', ()=>{
 
     it('compile scss with custom theme config', async () => {
         const hexo = new Hexo();
-        hexo.config.sass = { indentWidth: 1 };
-        hexo.theme.config.sass = { indentWidth: 4 };
+        hexo.config.sass = {indentWidth: 1};
+        hexo.theme.config.sass = {indentWidth: 4};
         const data: Hexo.extend.RendererData = {
             path: __dirname + '/files/default.scss',
-            text: ''
+            text: '',
         };
         const result = await make.call(hexo, data, {});
         expect(result).toBe('html body {\n width: 100%;\n}')
@@ -39,7 +39,7 @@ describe('Function `make`', ()=>{
         const hexo = new Hexo();
         const data: Hexo.extend.RendererData = {
             path: __dirname + '/files/error.scss',
-            text: ''
+            text: '',
         };
 
         const fnuc = make.call(hexo, data, {});
@@ -50,9 +50,35 @@ describe('Function `make`', ()=>{
         const hexo = new Hexo();
         const data: Hexo.extend.RendererData = {
             path: __dirname + '/files/default.sass',
-            text: ''
+            text: '',
         };
         const result = await make.call(hexo, data, {});
         expect(result).toBe('html body {\n  width: 100%;\n}')
+    });
+
+    it('compile scss with default settings and spec config', async () => {
+        const hexo = new Hexo();
+        hexo.theme.config.color = '#000';
+        hexo.theme.config.node_sass = {debug: true};
+        hexo.config.color = '#FFF';
+        const data: Hexo.extend.RendererData = {
+            path: __dirname + '/files/default-spec-config.scss',
+            text: '',
+        };
+        const result = await make.call(hexo, data, {});
+        expect(result).toBe('html body {\n  width: 100%;\n  background: #000;\n  color: #fff;\n}')
+    });
+
+    it('compile sass with default settings and spec config', async () => {
+        const hexo = new Hexo();
+        hexo.theme.config.color = '#000';
+        hexo.theme.config.node_sass = {debug: true};
+        hexo.config.color = '#FFF';
+        const data: Hexo.extend.RendererData = {
+            path: __dirname + '/files/default-spec-config.sass',
+            text: '',
+        };
+        const result = await make.call(hexo, data, {});
+        expect(result).toBe('html body {\n  width: 100%;\n  background: #000;\n  color: #fff;\n}')
     });
 });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,21 +1,82 @@
 import Hexo = require('hexo');
 import sass = require('sass');
+import { LegacyOptions } from 'sass/types/legacy/options';
 
-export const make = function(this: Hexo, data: Hexo.extend.RendererData, options: {[key:string]:any}){
+export const make = function (this: Hexo, data: Hexo.extend.RendererData, options: {
+    [key: string]: any
+}) {
 
-    const config = Object.assign(
-        this.theme.config.sass || {},
-        this.config.sass || {},
-        {file: data.path}
+    const self = this;
+    const themeCfg = self.theme.config || {};
+
+    // support global and theme-specific config
+    const userConfig = Object.assign(
+        themeCfg.node_sass || {},
+        self.config.node_sass || {},
     );
 
-    return new Promise<string>((resolve, reject)=>{
+    function getProperty(obj: any, name: string) {
+        name = name.replace(/\[(\w+)]/g, '.$1').replace(/^\./, '');
+
+        const split = name.split('.');
+        let key = split.shift();
+
+        if (!obj.hasOwnProperty(key)) return '';
+        if (!key) {
+            return '';
+        }
+        let result = obj[key];
+        const len = split.length;
+
+        if (!len) return result || '';
+        if (typeof result !== 'object') return '';
+
+        for (let i = 0; i < len; i++) {
+            key = split[i];
+            if (!result.hasOwnProperty(key)) return '';
+
+            result = result[split[i]];
+            if (typeof result !== 'object') return result;
+        }
+
+        return result;
+    }
+
+    const config: LegacyOptions<'async'> = Object.assign(
+        this.theme.config.sass || {},
+        this.config.sass || {},
+        {file: data.path},
+        {
+            functions: {
+                'hexo-theme-config($ckey)': function (ckey: any) {
+                    const val = getProperty(themeCfg, ckey.getValue()),
+                        sassVal = new sass.types.String(val);
+                    if (userConfig.debug) {
+                        console.log('hexo-theme-config.' + ckey.getValue(), val);
+                    }
+                    return sassVal;
+                },
+                'hexo-config($ckey)': function (ckey: any) {
+                    const val = getProperty(self.config, ckey.getValue()),
+                        sassVal = new sass.types.String(val);
+                    if (userConfig.debug) {
+                        console.log('hexo-config.' + ckey.getValue(), val);
+                    }
+                    return sassVal;
+                },
+            },
+        },
+    );
+
+    return new Promise<string>((resolve, reject) => {
         sass.render(config, (err, result) => {
-            if(err) {
+            if (err) {
                 reject(err);
                 return;
             }
-            resolve(result.css.toString());
+            if (result) {
+                resolve(result.css.toString());
+            }
         });
     });
 }


### PR DESCRIPTION
There are some handy functions in [mamboer/hexo-renderer-scss](https://github.com/mamboer/hexo-renderer-scss) that used by some themes like [ahonn/hexo-theme-even](https://github.com/ahonn/hexo-theme-even)

Just using ts to implement same features and trying to resolve a issue https://github.com/ahonn/hexo-theme-even/issues/285

