### PR TITLE
fix: Stop using deprecated sass APIs

### DIFF
--- a/spec/files/default-spec-config.sass
+++ b/spec/files/default-spec-config.sass
@@ -1,5 +1,5 @@
 html
     body
         width: 100%
-        background: to-lower-case(call("hexo-theme-config", 'color'))
-        color: to-lower-case(call('hexo-config', 'color'))
+        background: to-lower-case(call(get-function("hexo-theme-config"), 'color'))
+        color: to-lower-case(call(get-function('hexo-config'), 'color'))

--- a/spec/files/default-spec-config.scss
+++ b/spec/files/default-spec-config.scss
@@ -1,7 +1,7 @@
 html {
     body {
         width: 100%;
-        background: to-lower-case(call("hexo-theme-config", 'color'));
-        color: to-lower-case(call('hexo-config', 'color'));
+        background: to-lower-case(call(get-function("hexo-theme-config"), 'color'));
+        color: to-lower-case(call(get-function('hexo-config'), 'color'));
     }
 }

--- a/spec/renderer.spec.ts
+++ b/spec/renderer.spec.ts
@@ -14,25 +14,13 @@ describe('Function `make`', () => {
 
     it('compile scss with custom config', async () => {
         const hexo = new Hexo();
-        hexo.config.sass = {indentWidth: 4};
+        hexo.config.sass = {style: "compressed"};
         const data: Hexo.extend.RendererData = {
             path: __dirname + '/files/default.scss',
             text: '',
         };
         const result = await make.call(hexo, data, {});
-        expect(result).toBe('html body {\n    width: 100%;\n}')
-    });
-
-    it('compile scss with custom theme config', async () => {
-        const hexo = new Hexo();
-        hexo.config.sass = {indentWidth: 1};
-        hexo.theme.config.sass = {indentWidth: 4};
-        const data: Hexo.extend.RendererData = {
-            path: __dirname + '/files/default.scss',
-            text: '',
-        };
-        const result = await make.call(hexo, data, {});
-        expect(result).toBe('html body {\n width: 100%;\n}')
+        expect(result).toBe('html body{width:100%}')
     });
 
     it('throw error with invalid scss syntax', async () => {
@@ -59,7 +47,6 @@ describe('Function `make`', () => {
     it('compile scss with default settings and spec config', async () => {
         const hexo = new Hexo();
         hexo.theme.config.color = '#000';
-        hexo.theme.config.node_sass = {debug: true};
         hexo.config.color = '#FFF';
         const data: Hexo.extend.RendererData = {
             path: __dirname + '/files/default-spec-config.scss',
@@ -72,7 +59,6 @@ describe('Function `make`', () => {
     it('compile sass with default settings and spec config', async () => {
         const hexo = new Hexo();
         hexo.theme.config.color = '#000';
-        hexo.theme.config.node_sass = {debug: true};
         hexo.config.color = '#FFF';
         const data: Hexo.extend.RendererData = {
             path: __dirname + '/files/default-spec-config.sass',


### PR DESCRIPTION
Stop using sass's [Legacy JS API](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/) and replace it with an implementation that complies with the latest specifications.

With this fix, old options defined only in [LegacyOptions](https://sass-lang.com/documentation/js-api/types/legacyoptions/) are no longer available.

None of these options are explicitly stated in our library's documentation, but if you set them in `_config.yml` from older sass documentation, previous behavior may be broken.