### PR TITLE
Modernize build toolchain and dependencies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,21 +1,20 @@
 name: test
 on:
   pull_request:
-    branches:
-      - master
   push:
-    branches:
-      - master
     tags:
       - "!*"
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm test
       - run: npm run build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-renderer-dartsass",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Sass renderer plugin for Hexo (use dartsass instead of libsass)",
   "main": "dist/",
   "files": [
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "jasmine-ts",
+    "test": "tsx node_modules/.bin/jasmine",
     "watch": "chokidar 'src/**/*.ts' 'spec/**/*.ts' -c 'npm test'"
   },
   "keywords": [
@@ -24,19 +24,19 @@
   ],
   "author": "KentarouTakeda",
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "sass": "^1.37.5"
   },
   "devDependencies": {
-    "@types/hexo": "^3.8.7",
-    "@types/jasmine": "^3.8.2",
-    "@types/sass": "^1.16.1",
+    "@types/jasmine": "^6.0.0",
+    "@types/node": "^25.6.0",
     "chokidar-cli": "^3.0.0",
-    "hexo": "^5.4.0",
-    "jasmine": "^3.8.0",
-    "jasmine-console-reporter": "^3.1.0",
-    "jasmine-ts": "^0.4.0",
-    "ts-node": "^10.2.0",
-    "typescript": "^5.6.3"
+    "hexo": "^7.0.0",
+    "jasmine": "^6.0.0",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2"
   }
 }

--- a/spec/renderer.spec.ts
+++ b/spec/renderer.spec.ts
@@ -1,10 +1,11 @@
-import Hexo from 'hexo';
+import Hexo = require('hexo');
 import { make } from '../src/renderer';
+import type { StoreFunctionData } from 'hexo/dist/extend/renderer';
 
 describe('Function `make`', () => {
     it('compile scss with default settings', async () => {
         const hexo = new Hexo();
-        const data: Hexo.extend.RendererData = {
+        const data: StoreFunctionData = {
             path: __dirname + '/files/default.scss',
             text: '',
         };
@@ -15,7 +16,7 @@ describe('Function `make`', () => {
     it('compile scss with custom config', async () => {
         const hexo = new Hexo();
         hexo.config.sass = {style: "compressed"};
-        const data: Hexo.extend.RendererData = {
+        const data: StoreFunctionData = {
             path: __dirname + '/files/default.scss',
             text: '',
         };
@@ -25,7 +26,7 @@ describe('Function `make`', () => {
 
     it('throw error with invalid scss syntax', async () => {
         const hexo = new Hexo();
-        const data: Hexo.extend.RendererData = {
+        const data: StoreFunctionData = {
             path: __dirname + '/files/error.scss',
             text: '',
         };
@@ -36,7 +37,7 @@ describe('Function `make`', () => {
 
     it('compile sass with default settings', async () => {
         const hexo = new Hexo();
-        const data: Hexo.extend.RendererData = {
+        const data: StoreFunctionData = {
             path: __dirname + '/files/default.sass',
             text: '',
         };
@@ -50,7 +51,7 @@ describe('Function `make`', () => {
         hexo.theme.config.names = ["asa", "barry", "carlo"];
         hexo.config.color = '#FFF';
         hexo.config.colors = ["white", "black", "orange"]
-        const data: Hexo.extend.RendererData = {
+        const data: StoreFunctionData = {
             path: __dirname + '/files/default-spec-config.scss',
             text: '',
         };
@@ -64,7 +65,7 @@ describe('Function `make`', () => {
         hexo.theme.config.names = ["asa", "barry", "carlo"];
         hexo.config.color = '#FFF';
         hexo.config.colors = ["white", "black", "orange"]
-        const data: Hexo.extend.RendererData = {
+        const data: StoreFunctionData = {
             path: __dirname + '/files/default-spec-config.sass',
             text: '',
         };

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -3,9 +3,6 @@
   "spec_files": [
     "**/*.spec.ts"
   ],
-  "helpers": [
-    "helpers/**/*.ts"
-  ],
   "stopSpecOnExpectationFailure": false,
   "random": true
 }

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "types": ["node", "jasmine"],
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../src/**/*.ts"],
+  "exclude": []
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,42 +1,38 @@
-import Hexo from 'hexo';
+import Hexo = require('hexo');
 import sass = require('sass');
+import type { StoreFunctionData } from 'hexo/dist/extend/renderer';
 
-export const make = async function (this: Hexo, data: Hexo.extend.RendererData, options: {
-    [key: string]: any
-}) {
+function getProperty(obj: any, name: string) {
+    name = name.replace(/\[(\w+)]/g, '.$1').replace(/^\./, '');
+
+    const split = name.split('.');
+    let key = split.shift();
+
+    if (!key || !Object.prototype.hasOwnProperty.call(obj, key)) return '';
+    let result = obj[key];
+    const len = split.length;
+
+    if (!len) return result || '';
+    if (typeof result !== 'object') return '';
+
+    for (let i = 0; i < len; i++) {
+        key = split[i];
+        if (!Object.prototype.hasOwnProperty.call(result, key)) return '';
+
+        result = result[split[i]];
+        if (typeof result !== 'object') return result;
+    }
+
+    return result;
+}
+
+export const make = async function (this: Hexo, data: StoreFunctionData, options: object) {
     if(data.path == null) {
         return '';
     }
 
     const self = this;
     const themeCfg = self.theme.config || {};
-
-    function getProperty(obj: any, name: string) {
-        name = name.replace(/\[(\w+)]/g, '.$1').replace(/^\./, '');
-
-        const split = name.split('.');
-        let key = split.shift();
-
-        if (!obj.hasOwnProperty(key)) return '';
-        if (!key) {
-            return '';
-        }
-        let result = obj[key];
-        const len = split.length;
-
-        if (!len) return result || '';
-        if (typeof result !== 'object') return '';
-
-        for (let i = 0; i < len; i++) {
-            key = split[i];
-            if (!result.hasOwnProperty(key)) return '';
-
-            result = result[split[i]];
-            if (typeof result !== 'object') return result;
-        }
-
-        return result;
-    }
 
     const config: sass.Options<'async'> = Object.assign(
         this.theme.config.sass || {},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
-    "esModuleInterop": true,
+    "moduleResolution": "bundler",
     "outDir": "./dist",
     "rootDir": "./src",
-    "strict": true,
     "noImplicitReturns": true,
-    "lib": ["ES7"]
+    "skipLibCheck": true,
+    "types": ["node"],
+    "lib": ["ES2020"]
   },
   "exclude": [
     "spec/**/*"


### PR DESCRIPTION
## Summary
- Upgrade TypeScript 5 → 6, hexo 5 → 7, jasmine 3 → 6
- Replace deprecated jasmine-ts/ts-node with tsx
- Upgrade tsconfig target from ES5 to ES2020 (removes __awaiter polyfill from dist output)
- Remove unnecessary @types/sass and @types/hexo
- Fix hasOwnProperty to use safe Object.prototype pattern
- Expand CI to all branches with Node 18/20/22 matrix

## Notes
- Public API unchanged: `make` function export and .scss/.sass renderer registration
- dist/ output is functionally equivalent (verified via diff and full test suite)
- Tested against real Hexo blog via npm link

## Test plan
- [x] All 6 specs pass on Node 24
- [x] `npm run build` succeeds with no errors
- [x] dist/ exports verified: `['make']`, AsyncFunction
- [x] Verified in consumer project (hexo blog) via `npm link` + `hexo g`