### PR TITLE
ci: modernize GitHub Actions workflows and adopt npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,18 +2,25 @@ name: publish
 on:
   release:
     types:
-      - created
+      - published
+
+concurrency:
+  group: publish
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment:
+      name: npm
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 18
-          registry-url: 'https://registry.npmjs.org'
+          node-version: 24
       - run: npm install
       - run: npm test
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --access public


### PR DESCRIPTION
## Summary

- Migrate npm publish authentication from `NPM_TOKEN` to OIDC trusted publishing
- Update `actions/checkout` and `actions/setup-node` from v4 to v6
- Add Node.js 24 to the test matrix and use it for publishing
- Add `concurrency`, `permissions`, and `environment` to the publish workflow
- Change release trigger from `created` to `published`

## Test plan

- [x] Verify CI passes on all matrix versions (18, 20, 22, 24)
- [ ] Verify publish workflow by creating a release